### PR TITLE
Bugfix due to debug lines

### DIFF
--- a/onlykey/okcore.cpp
+++ b/onlykey/okcore.cpp
@@ -2485,12 +2485,16 @@ if (PDmode) return;
     Serial.printf("Erase Sector 0x%X ",adr);
 #endif 
     if (flashEraseSector((unsigned long*)adr)) 
-#ifdef DEBUG     
     {
+#ifdef DEBUG   
 	Serial.printf("NOT ");
-    }
-    Serial.printf("successful\r\n"); 
 #endif 
+    }
+
+#ifdef DEBUG   
+    Serial.printf("successful\r\n"); 
+#endif
+
 	//Write buffer to flash
 	ptr=buffer+5;
     onlykey_flashset_common(ptr, (unsigned long*)adr, 32);
@@ -2703,12 +2707,16 @@ if (PDmode) return;
     Serial.printf("Erase Sector 0x%X ",adr);
 #endif 
     if (flashEraseSector((unsigned long*)adr)) 
-#ifdef DEBUG     
     {
+#ifdef DEBUG   
 	Serial.printf("NOT ");
-    }
-    Serial.printf("successful\r\n"); 
 #endif 
+    }
+
+#ifdef DEBUG   
+    Serial.printf("successful\r\n"); 
+#endif
+
 	//Write buffer to flash
 	ptr=buffer+5;
     onlykey_flashset_common(ptr, (unsigned long*)adr, 32);


### PR DESCRIPTION
I spotted the issue, without debug mode here's what was happening:

```
    if (flashEraseSector((unsigned long*)adr)) 
 	//Write buffer to flash
 	ptr=buffer+5;
```

So the pointer get increased only if the `flashEraseSector` failed.

I fixed it both for U2F and SSH. I haven't tried, send me the compiled build if you want me to try it out!